### PR TITLE
Implement catalog browse REST endpoint (FEAT-CAT-1, minimal skeleton)

### DIFF
--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogController.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogController.java
@@ -1,0 +1,33 @@
+package dev.ronin.demo.beerstore.product.adapter.in.rest;
+
+import dev.ronin.demo.beerstore.shared.api.CatalogApi;
+import dev.ronin.demo.beerstore.shared.api.model.BeerDto;
+import dev.ronin.demo.beerstore.shared.api.model.BeerSortFieldDto;
+import dev.ronin.demo.beerstore.shared.api.model.BeerStyleDto;
+import dev.ronin.demo.beerstore.shared.api.model.SortDirectionDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RestController
+public class CatalogController implements CatalogApi {
+
+    private final CatalogRestAdapter catalogRestAdapter;
+
+    public CatalogController(CatalogRestAdapter catalogRestAdapter) {
+        this.catalogRestAdapter = catalogRestAdapter;
+    }
+
+    @Override
+    public ResponseEntity<List<BeerDto>> browseBeers(String name, BeerStyleDto style, Double minAbv, Double maxAbv,
+            BigDecimal minPrice, BigDecimal maxPrice, BeerSortFieldDto sortBy, SortDirectionDto sortDirection) {
+        return ResponseEntity.ok(catalogRestAdapter.browse());
+    }
+
+    @Override
+    public ResponseEntity<BeerDto> getBeerById(Long id) {
+        return ResponseEntity.ok(catalogRestAdapter.beerWithId(id));
+    }
+}

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogMapper.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogMapper.java
@@ -1,0 +1,18 @@
+package dev.ronin.demo.beerstore.product.adapter.in.rest;
+
+import dev.ronin.demo.beerstore.product.api.view.BeerView;
+import dev.ronin.demo.beerstore.shared.api.model.BeerDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper
+public interface CatalogMapper {
+
+    @Mapping(target = "price", source = "price.amount")
+    @Mapping(target = "status", ignore = true) // no domain source yet - see ADR/next round (BeerStatus)
+    BeerDto toDto(BeerView beerView);
+
+    List<BeerDto> toDtoList(List<BeerView> beerViews);
+}

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogRestAdapter.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogRestAdapter.java
@@ -1,0 +1,34 @@
+package dev.ronin.demo.beerstore.product.adapter.in.rest;
+
+import dev.ronin.demo.beerstore.product.api.BeerManagement;
+import dev.ronin.demo.beerstore.product.api.query.GetBeer;
+import dev.ronin.demo.beerstore.shared.api.model.BeerDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Bridges the generated {@link dev.ronin.demo.beerstore.shared.api.CatalogApi} wire contract to
+ * {@link BeerManagement}. The contract already declares filter/sort query parameters
+ * (name/style/minAbv/maxAbv/minPrice/maxPrice/sortBy/sortDirection) for a future round - this
+ * first, minimal-skeleton round only lists every beer / fetches one by id, and ignores them.
+ */
+@Service
+public class CatalogRestAdapter {
+
+    private final BeerManagement beerManagement;
+    private final CatalogMapper catalogMapper;
+
+    public CatalogRestAdapter(BeerManagement beerManagement, CatalogMapper catalogMapper) {
+        this.beerManagement = beerManagement;
+        this.catalogMapper = catalogMapper;
+    }
+
+    public List<BeerDto> browse() {
+        return catalogMapper.toDtoList(beerManagement.listBeers());
+    }
+
+    public BeerDto beerWithId(Long id) {
+        return catalogMapper.toDto(beerManagement.getBeer(new GetBeer(id)));
+    }
+}

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogRestExceptionHandler.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogRestExceptionHandler.java
@@ -1,0 +1,23 @@
+package dev.ronin.demo.beerstore.product.adapter.in.rest;
+
+import dev.ronin.demo.beerstore.platform.rest.ErrorDetails;
+import dev.ronin.demo.beerstore.product.api.exception.BeerNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Maps the product module's own domain exceptions to HTTP responses. Kept in this module (rather
+ * than a global handler) because {@code platform} must not depend on business modules - see
+ * {@code platform.rest.CommonRestExceptionHandler}, which still handles the exceptions common to
+ * every module (generic not-found, validation, authorization).
+ */
+@RestControllerAdvice
+public class CatalogRestExceptionHandler {
+
+    @ExceptionHandler(BeerNotFoundException.class)
+    public ResponseEntity<ErrorDetails> beerNotFoundException(final BeerNotFoundException e) {
+        return new ResponseEntity<>(new ErrorDetails(e.getMessage(), e.getMessage()), HttpStatus.NOT_FOUND);
+    }
+}

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/out/persistence/jpa/BeerPersistenceAdapter.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/out/persistence/jpa/BeerPersistenceAdapter.java
@@ -5,6 +5,7 @@ import dev.ronin.demo.beerstore.product.domain.model.Beer;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class BeerPersistenceAdapter implements BeerRepository {
@@ -20,6 +21,16 @@ public class BeerPersistenceAdapter implements BeerRepository {
     @Override
     public List<Beer> findAllById(List<Long> ids) {
         return jpaRepository.findAllById(ids).stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public List<Beer> findAll() {
+        return jpaRepository.findAll().stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    public Optional<Beer> findById(Long id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
     }
 
     @Override

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/out/persistence/jpa/entity/BeerJpaEntity.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/adapter/out/persistence/jpa/entity/BeerJpaEntity.java
@@ -23,5 +23,7 @@ public class BeerJpaEntity {
     @Enumerated(EnumType.STRING)
     private BeerStyle beerStyle;
 
+    private double abv;
+
     private BigDecimal priceAmount;
 }

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/BeerManagement.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/BeerManagement.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import dev.ronin.demo.beerstore.product.api.command.CreateBeer;
 import dev.ronin.demo.beerstore.product.api.query.FindBeers;
+import dev.ronin.demo.beerstore.product.api.query.GetBeer;
 import dev.ronin.demo.beerstore.product.api.view.BeerView;
 
 /**
@@ -15,6 +16,10 @@ import dev.ronin.demo.beerstore.product.api.view.BeerView;
 public interface BeerManagement {
 
     List<BeerView> findAllById(FindBeers query);
+
+    List<BeerView> listBeers();
+
+    BeerView getBeer(GetBeer query);
 
     BeerView createBeer(CreateBeer command);
 }

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/command/CreateBeer.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/command/CreateBeer.java
@@ -3,5 +3,5 @@ package dev.ronin.demo.beerstore.product.api.command;
 import dev.ronin.demo.beerstore.product.api.type.BeerStyle;
 import dev.ronin.demo.beerstore.shared.kernel.Money;
 
-public record CreateBeer(String name, BeerStyle beerStyle, Money price) {
+public record CreateBeer(String name, BeerStyle beerStyle, double abv, Money price) {
 }

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/exception/BeerNotFoundException.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/exception/BeerNotFoundException.java
@@ -1,0 +1,8 @@
+package dev.ronin.demo.beerstore.product.api.exception;
+
+public class BeerNotFoundException extends RuntimeException {
+
+    public BeerNotFoundException(Long id) {
+        super("Beer not found: id=" + id);
+    }
+}

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/exception/package-info.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/exception/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("api")
+package dev.ronin.demo.beerstore.product.api.exception;

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/query/GetBeer.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/query/GetBeer.java
@@ -1,0 +1,4 @@
+package dev.ronin.demo.beerstore.product.api.query;
+
+public record GetBeer(Long id) {
+}

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/view/BeerView.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/api/view/BeerView.java
@@ -3,5 +3,5 @@ package dev.ronin.demo.beerstore.product.api.view;
 import dev.ronin.demo.beerstore.product.api.type.BeerStyle;
 import dev.ronin.demo.beerstore.shared.kernel.Money;
 
-public record BeerView(Long id, String name, BeerStyle beerStyle, Money price) {
+public record BeerView(Long id, String name, BeerStyle beerStyle, double abv, Money price) {
 }

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/application/port/out/BeerRepository.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/application/port/out/BeerRepository.java
@@ -4,11 +4,16 @@ import dev.ronin.demo.beerstore.product.domain.model.Beer;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BeerRepository {
 
     List<Beer> findAllById(List<Long> ids);
+
+    List<Beer> findAll();
+
+    Optional<Beer> findById(Long id);
 
     Beer save(Beer data);
 }

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/application/service/Beers.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/application/service/Beers.java
@@ -2,7 +2,9 @@ package dev.ronin.demo.beerstore.product.application.service;
 
 import dev.ronin.demo.beerstore.product.api.BeerManagement;
 import dev.ronin.demo.beerstore.product.api.command.CreateBeer;
+import dev.ronin.demo.beerstore.product.api.exception.BeerNotFoundException;
 import dev.ronin.demo.beerstore.product.api.query.FindBeers;
+import dev.ronin.demo.beerstore.product.api.query.GetBeer;
 import dev.ronin.demo.beerstore.product.api.view.BeerView;
 import dev.ronin.demo.beerstore.product.application.port.out.BeerRepository;
 import dev.ronin.demo.beerstore.product.domain.model.Beer;
@@ -27,13 +29,27 @@ public class Beers implements BeerManagement {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<BeerView> listBeers() {
+        return beerRepository.findAll().stream().map(Beers::toView).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BeerView getBeer(GetBeer query) {
+        return beerRepository.findById(query.id()).map(Beers::toView)
+                .orElseThrow(() -> new BeerNotFoundException(query.id()));
+    }
+
+    @Override
     @Transactional
     public BeerView createBeer(CreateBeer command) {
-        Beer saved = beerRepository.save(Beer.create(command.name(), command.beerStyle(), command.price()));
+        Beer saved = beerRepository.save(
+                Beer.create(command.name(), command.beerStyle(), command.abv(), command.price()));
         return toView(saved);
     }
 
     private static BeerView toView(Beer beer) {
-        return new BeerView(beer.id(), beer.name(), beer.beerStyle(), beer.price());
+        return new BeerView(beer.id(), beer.name(), beer.beerStyle(), beer.abv(), beer.price());
     }
 }

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/domain/model/Beer.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/domain/model/Beer.java
@@ -7,26 +7,34 @@ import java.util.Objects;
 
 /**
  * The beer aggregate. Self-validating (a {@code name} must not be blank, {@code beerStyle}/
- * {@code price} must not be null) via the compact constructor, so a {@link Beer} is always in a
- * valid state once constructed - unlike the previous bare-record version that enforced nothing.
- * {@link #create(String, BeerStyle, Money)} is the single entry point for bringing a new beer
- * into existence (id is DB-assigned, so it's deliberately not a constructor parameter here).
+ * {@code price} must not be null, {@code abv} must be within 0..100) via the compact constructor,
+ * so a {@link Beer} is always in a valid state once constructed - unlike the previous bare-record
+ * version that enforced nothing. {@link #create(String, BeerStyle, double, Money)} is the single
+ * entry point for bringing a new beer into existence (id is DB-assigned, so it's deliberately not
+ * a constructor parameter here).
  */
-public record Beer(Long id, String name, BeerStyle beerStyle, Money price) {
+public record Beer(Long id, String name, BeerStyle beerStyle, double abv, Money price) {
 
     public Beer {
         requireNonBlank(name, "name");
         Objects.requireNonNull(beerStyle, "beerStyle must not be null");
+        requireValidAbv(abv);
         Objects.requireNonNull(price, "price must not be null");
     }
 
-    public static Beer create(String name, BeerStyle beerStyle, Money price) {
-        return new Beer(null, name, beerStyle, price);
+    public static Beer create(String name, BeerStyle beerStyle, double abv, Money price) {
+        return new Beer(null, name, beerStyle, abv, price);
     }
 
     private static void requireNonBlank(String value, String field) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException(field + " must not be blank");
+        }
+    }
+
+    private static void requireValidAbv(double abv) {
+        if (abv < 0 || abv > 100) {
+            throw new IllegalArgumentException("abv must be between 0 and 100");
         }
     }
 }

--- a/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/package-info.java
+++ b/beer-store-application/src/main/java/dev/ronin/demo/beerstore/product/package-info.java
@@ -5,10 +5,11 @@
  * Spring Modulith named interface, contributed to by every {@code api.*} subpackage); every other
  * subpackage ({@code domain}, {@code application}, {@code adapter}) is an implementation detail
  * hidden by Spring Modulith's default rule (module subpackages are internal unless annotated
- * {@code @NamedInterface}), including the {@code Beer} aggregate itself. Depends on nothing
- * else besides the always-open {@code shared} module - unlike
- * {@code customer}/{@code order}, product has no inbound REST adapter yet, so it needs neither
- * {@code platform :: rest} nor {@code platform :: security}.
+ * {@code @NamedInterface}), including the {@code Beer} aggregate itself. Its inbound REST adapter
+ * (the {@code catalog} browse endpoints) also uses the (Modulith-excluded) {@code platform}
+ * package's {@code rest} type ({@code ErrorDetails}) besides the always-open {@code shared}
+ * module - the browse endpoints are not yet public, so {@code platform :: security} is not needed
+ * (unlike customer/order, which use {@code Authorized} for admin-only operations).
  */
 @ApplicationModule(allowedDependencies = {"shared"})
 package dev.ronin.demo.beerstore.product;

--- a/beer-store-application/src/main/resources/database/changelog/1.2.0/add-beer-abv.xml
+++ b/beer-store-application/src/main/resources/database/changelog/1.2.0/add-beer-abv.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd">
+
+    <changeSet author="pkormoczi" id="add_beer_abv" logicalFilePath="db/changelog/1.2.0/add-beer-abv.xml">
+        <addColumn tableName="beer">
+            <column defaultValueNumeric="0" name="abv" type="DOUBLE">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/beer-store-application/src/main/resources/database/changelog/1.2.0/changelog.xml
+++ b/beer-store-application/src/main/resources/database/changelog/1.2.0/changelog.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd">
+
+    <include file="/database/changelog/1.2.0/add-beer-abv.xml"/>
+
+</databaseChangeLog>

--- a/beer-store-application/src/main/resources/database/changelog/changelog-master.xml
+++ b/beer-store-application/src/main/resources/database/changelog/changelog-master.xml
@@ -6,5 +6,6 @@
 
     <include file="/database/changelog/1.0.0/changelog.xml"/>
     <include file="/database/changelog/1.1.0/changelog.xml"/>
+    <include file="/database/changelog/1.2.0/changelog.xml"/>
 
 </databaseChangeLog>

--- a/beer-store-application/src/test/java/dev/ronin/demo/beerstore/order/adapter/in/rest/OrdersIT.java
+++ b/beer-store-application/src/test/java/dev/ronin/demo/beerstore/order/adapter/in/rest/OrdersIT.java
@@ -38,7 +38,7 @@ public class OrdersIT extends IntegrationTest {
         CustomerView savedCustomer = customerManagement.registerCustomer(new RegisterCustomer("First", "Last",
                 new Address("Hungary", "1095", "Budapest", "Teszt utca 1")));
         BeerView savedBeer = beerManagement.createBeer(
-                new CreateBeer("Csoda IPA", BeerStyle.IPA, new Money(new BigDecimal("2.50"))));
+                new CreateBeer("Csoda IPA", BeerStyle.IPA, 5.5, new Money(new BigDecimal("2.50"))));
         OrderDto given = givenOrder(savedCustomer.id(), savedBeer.id());
         //When
         ResponseEntity<Long> result = orderController.createOrder(given);

--- a/beer-store-application/src/test/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogIT.java
+++ b/beer-store-application/src/test/java/dev/ronin/demo/beerstore/product/adapter/in/rest/CatalogIT.java
@@ -1,0 +1,69 @@
+package dev.ronin.demo.beerstore.product.adapter.in.rest;
+
+import dev.ronin.demo.beerstore.base.IntegrationTest;
+import dev.ronin.demo.beerstore.product.api.BeerManagement;
+import dev.ronin.demo.beerstore.product.api.command.CreateBeer;
+import dev.ronin.demo.beerstore.product.api.exception.BeerNotFoundException;
+import dev.ronin.demo.beerstore.product.api.type.BeerStyle;
+import dev.ronin.demo.beerstore.product.api.view.BeerView;
+import dev.ronin.demo.beerstore.shared.api.model.BeerDto;
+import dev.ronin.demo.beerstore.shared.kernel.Money;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CatalogIT extends IntegrationTest {
+
+    @Autowired
+    CatalogController catalogController;
+
+    @Autowired
+    BeerManagement beerManagement;
+
+    @Test
+    @DisplayName("Browse returns every beer in the catalog")
+    void browseReturnsEveryBeer() {
+        //Given
+        BeerView first = beerManagement.createBeer(
+                new CreateBeer("Csoda IPA", BeerStyle.IPA, 5.5, new Money(new BigDecimal("2.50"))));
+        BeerView second = beerManagement.createBeer(
+                new CreateBeer("Bakony Lager", BeerStyle.LAGER, 4.8, new Money(new BigDecimal("1.90"))));
+        //When
+        ResponseEntity<List<BeerDto>> result = catalogController.browseBeers(
+                null, null, null, null, null, null, null, null);
+        //Then
+        assertThat(result.getBody())
+                .extracting(BeerDto::getId)
+                .contains(first.id(), second.id());
+    }
+
+    @Test
+    @DisplayName("Fetching a beer by id returns its full details")
+    void getBeerByIdReturnsBeer() {
+        //Given
+        BeerView saved = beerManagement.createBeer(
+                new CreateBeer("Csoda IPA", BeerStyle.IPA, 5.5, new Money(new BigDecimal("2.50"))));
+        //When
+        ResponseEntity<BeerDto> result = catalogController.getBeerById(saved.id());
+        //Then
+        BeerDto body = result.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.getName()).isEqualTo("Csoda IPA");
+        assertThat(body.getAbv()).isEqualTo(5.5);
+        assertThat(body.getPrice()).isEqualByComparingTo("2.50");
+    }
+
+    @Test
+    @DisplayName("Fetching a non-existent beer throws")
+    void getBeerByIdThrowsWhenMissing() {
+        assertThatThrownBy(() -> catalogController.getBeerById(999_999L))
+                .isInstanceOf(BeerNotFoundException.class);
+    }
+}

--- a/beer-store-application/src/test/java/dev/ronin/demo/beerstore/product/domain/model/BeerTest.java
+++ b/beer-store-application/src/test/java/dev/ronin/demo/beerstore/product/domain/model/BeerTest.java
@@ -13,36 +13,52 @@ import static org.assertj.core.api.BDDAssertions.then;
 class BeerTest {
 
     private static final Money PRICE = new Money(new BigDecimal("2.50"));
+    private static final double ABV = 5.5;
 
     @Test
     @DisplayName("A newly created beer has no id and the given attributes")
     void createBuildsUnsavedBeer() {
-        Beer beer = Beer.create("Csoda IPA", BeerStyle.IPA, PRICE);
+        Beer beer = Beer.create("Csoda IPA", BeerStyle.IPA, ABV, PRICE);
 
         then(beer.id()).isNull();
         then(beer.name()).isEqualTo("Csoda IPA");
         then(beer.beerStyle()).isEqualTo(BeerStyle.IPA);
+        then(beer.abv()).isEqualTo(ABV);
         then(beer.price()).isEqualTo(PRICE);
     }
 
     @Test
     @DisplayName("A blank name is rejected")
     void blankNameIsRejected() {
-        assertThatThrownBy(() -> Beer.create("  ", BeerStyle.IPA, PRICE))
+        assertThatThrownBy(() -> Beer.create("  ", BeerStyle.IPA, ABV, PRICE))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("A null beer style is rejected")
     void nullBeerStyleIsRejected() {
-        assertThatThrownBy(() -> Beer.create("Csoda IPA", null, PRICE))
+        assertThatThrownBy(() -> Beer.create("Csoda IPA", null, ABV, PRICE))
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("A negative abv is rejected")
+    void negativeAbvIsRejected() {
+        assertThatThrownBy(() -> Beer.create("Csoda IPA", BeerStyle.IPA, -0.1, PRICE))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("An abv above 100 is rejected")
+    void abvAboveMaxIsRejected() {
+        assertThatThrownBy(() -> Beer.create("Csoda IPA", BeerStyle.IPA, 100.1, PRICE))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("A null price is rejected")
     void nullPriceIsRejected() {
-        assertThatThrownBy(() -> Beer.create("Csoda IPA", BeerStyle.IPA, null))
+        assertThatThrownBy(() -> Beer.create("Csoda IPA", BeerStyle.IPA, ABV, null))
                 .isInstanceOf(NullPointerException.class);
     }
 }


### PR DESCRIPTION
## Summary

Second, **Java implementation** round of **FEAT-CAT-1** (first round was the contract-only PR #10): wires `GET /catalog` and `GET /catalog/{id}` to a live `CatalogController`, built as a minimal skeleton on top of the already-merged `beer-store-contract` catalog endpoints.

### Domain
- `Beer` aggregate / `BeerView` / `CreateBeer` gain an `abv` field (`double`, self-validated 0..100 in the compact constructor).
- `BeerManagement` gains `listBeers()` and `getBeer(GetBeer)`; new `BeerNotFoundException` (`api.exception`, mirrors `OrderNotFoundException`'s single-scenario public-constructor style).
- `BeerRepository`/`BeerPersistenceAdapter` gain `findAll()`/`findById()`; `BeerJpaEntity.abv` + new Liquibase migration (`1.2.0/add-beer-abv.xml`, `NOT NULL DEFAULT 0`, mirrors `add-beer-price.xml`).

### REST adapter (new `product/adapter/in/rest`, mirrors customer/order)
- `CatalogController implements CatalogApi` → `CatalogRestAdapter` (`@Service`) → `BeerManagement`.
- `CatalogMapper` (MapStruct): `BeerView → BeerDto`, `Money → BigDecimal`, `BeerStyle → BeerStyleDto` auto-mapped.
- `CatalogRestExceptionHandler`: `BeerNotFoundException` → 404.

### Explicitly out of scope this round (per plan)
- The 8 filter/sort query parameters already declared on the contract (`name`/`style`/`minAbv`/`maxAbv`/`minPrice`/`maxPrice`/`sortBy`/`sortDirection`) are accepted but **ignored** — `browseBeers` currently returns every beer. A following round wires them up via a JPA `Specification`.
- `BeerStatus`/ACTIVE-only filtering, Spring Cloud Contract tests for `/catalog`, and making the endpoint public (currently behind the same `ROLE_USER` as `/orders`/`/customers`) are deferred rounds too.

### Verification
- Full reactor build (`mvn clean install`) ✅
- `mvn test`: 91/91, including all 9 architecture test classes + `ModularityTests` (Modulith `verify()`) ✅
- `mvn verify`: 9/9 integration tests, including the new `CatalogIT` (3 cases: browse, get-by-id, not-found) against real Postgres via Testcontainers — confirms the `abv DOUBLE` Liquibase migration matches Hibernate's `ddl-auto: validate` expectation ✅
- Local `/code-review` pass (3 parallel finder angles + verification): one low-severity consistency finding (`BeerNotFoundException`'s factory-method style vs. the closer `OrderNotFoundException` precedent) found and fixed before this PR; everything else clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)